### PR TITLE
Importer build time improvements

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -3,7 +3,7 @@ let
 in
 { system ? builtins.currentSystem
 , config ? {}
-, gitrev ? localLib.commitIdFromGitRepo ./.git
+, gitrev ? "beta"
 , buildId ? null
 , pkgs ? (import (localLib.fetchNixPkgs) { inherit system config; })
 # should enable or disable all checkPhases for cardano libraries,


### PR DESCRIPTION
This disables the `checkPhase`s of the cardano tooling when building the importer with nix.
See commit descriptions for more information.