### PR TITLE
docker.nix: patch wait-for-it to silence which error

### DIFF
--- a/docker.nix
+++ b/docker.nix
@@ -37,6 +37,8 @@ let
     in pkgs.runCommand "wait-for-it" {} ''
       mkdir -p $out/bin
       install "${file}" $out/bin/wait-for-it.sh
+      substituteInPlace $out/bin/wait-for-it.sh \
+        --replace "which" "type -p"
       patchShebangs $out/bin/wait-for-it.sh
     '';
 


### PR DESCRIPTION
Minor fix; the missing `which` didn’t cause any failures, but it looked like something was wrong with the startup.
