### PR TITLE
Fix double-transaction bug

### DIFF
--- a/blockchain-importer/src/Pos/BlockchainImporter/Tables/Utils.hs
+++ b/blockchain-importer/src/Pos/BlockchainImporter/Tables/Utils.hs
@@ -100,7 +100,7 @@ runUpsertUnlessSuccess_ conn table pkCheckConflict colUpdateOnConflict columns =
   where strInsertQuery col = O.arrangeInsertManySql table col
         strUpsertQuery col = (strInsertQuery col)  ++ " ON CONFLICT (" ++ pksString  ++ ") " ++
                              (updateColumnsToOnConflict colUpdateOnConflict) ++
-                             ("WHERE EXCLUDED.tx_state != " ++ (show Successful))
+                             (" WHERE EXCLUDED.tx_state != " ++ (show Successful))
         pksString      = intercalate ", " pkCheckConflict
 
 

--- a/blockchain-importer/src/Pos/BlockchainImporter/Tables/Utils.hs
+++ b/blockchain-importer/src/Pos/BlockchainImporter/Tables/Utils.hs
@@ -10,6 +10,9 @@ module Pos.BlockchainImporter.Tables.Utils
   , toTxOutAux
     -- * Postgres
   , runUpsert_
+  , runUpsertUnlessSuccess_
+    -- * helpers
+  , TxState (..)
   ) where
 
 import           Universum
@@ -78,6 +81,28 @@ runUpsert_ conn table pkCheckConflict colUpdateOnConflict columns = case nonEmpt
                              updateColumnsToOnConflict colUpdateOnConflict
         pksString      = intercalate ", " pkCheckConflict
 
+{-
+  We want to disable setting a SUCCESSFUL transaction to FAILED since 
+  1) This transition should not be possible according to ur state diagram
+  2) It may happen that when sending 2 identical transactions to the backend, one is rejected  as "FAILED"
+    This will override the "SUCCESSFUL" status even if the transaction really is in the blockchain
+-}
+runUpsertUnlessSuccess_ ::
+     PGS.Connection             -- Connection to the SQL DB
+  -> O.Table columns columns'   -- Table to perform the upsert on
+  -> [String]                   -- Primary keys to check if columns are present
+  -> [String]                   -- Names of the columns to update
+  -> [columns]                  -- Rows to insert
+  -> IO Int64
+runUpsertUnlessSuccess_ conn table pkCheckConflict colUpdateOnConflict columns = case nonEmpty columns of
+    Just neColumns -> PGS.execute_ conn . fromString $ strUpsertQuery neColumns
+    Nothing        -> return 0
+  where strInsertQuery col = O.arrangeInsertManySql table col
+        strUpsertQuery col = (strInsertQuery col)  ++ " ON CONFLICT (" ++ pksString  ++ ") " ++
+                             (updateColumnsToOnConflict colUpdateOnConflict) ++
+                             ("WHERE EXCLUDED.tx_state != " ++ (show Successful))
+        pksString      = intercalate ", " pkCheckConflict
+
 
 ----------------------------------------------------------------------------
 -- Helpers
@@ -87,3 +112,9 @@ updateColumnsToOnConflict :: [String] -> String
 updateColumnsToOnConflict []              = "DO NOTHING"
 updateColumnsToOnConflict columnsToUpdate = "DO UPDATE SET " ++ doUpdateSet
   where doUpdateSet = intercalate ", " $ (\col -> col ++ "=EXCLUDED." ++ col) <$> columnsToUpdate
+
+data TxState = 
+    Successful
+  | Failed
+  | Pending
+  deriving (Show, Read)

--- a/default.nix
+++ b/default.nix
@@ -148,6 +148,20 @@ let
           # additionalNodeArgs = ""; TODO?
         };
       };
+      mainnetBlockchainImporter = mkDocker {
+        environment = "mainnet";
+        connectArgs = {
+          executable = "blockchain-importer";
+          # additionalNodeArgs = ""; TODO?
+        };
+      };
+      stagingBlockchainImporter = mkDocker {
+        environment = "mainnet-staging";
+        connectArgs = {
+          executable = "blockchain-importer";
+          # additionalNodeArgs = ""; TODO?
+        };
+      };
     };
 
     daedalus-bridge = let


### PR DESCRIPTION
## Description

Sending the same valid transaction twice (such as may happen under poor networking conditions) will cause one transaction to succeed and the other to fail.
This is expected behavior but the problem is that the resulting DB state is that the transaction "failed" despite it being properly included in the blockchain.

Fix:
Since a transition from "successful" -> "failed" is not possible in our spec, we simply make it impossible for a "failed" transaction to change the DB status from "failed" -> "successful"

## Linked issue

N/A

## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply and `~` in the ones that do not: -->
- [~] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🛠 New feature (non-breaking change which adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🏭 Refactoring that does not change existing functionality but does improve things like code readability, structure etc
- [ ] 🔨 New or improved tests for existing code
- [ ] ⛑ git-flow chore (backport, hotfix, etc)
