### PR TITLE
Fixed flipped boolean return

### DIFF
--- a/blockchain-importer/src/Pos/BlockchainImporter/Txp/Toil/Logic.hs
+++ b/blockchain-importer/src/Pos/BlockchainImporter/Txp/Toil/Logic.hs
@@ -174,8 +174,8 @@ eCheckSuccessfulToil :: (MonadIO m, MonadDBRead m, HasPostGresDB) => Tx -> m Boo
 eCheckSuccessfulToil tx = do
   maybeTx <- liftIO $ postGreOperate $ TxsT.getTxByHash (hash tx)
   pure $ case maybeTx of
-        Just (TxsT.TxRecord _ _ _ _ _ TxsT.Successful) -> False
-        _                                              -> True
+        Just (TxsT.TxRecord _ _ _ _ _ TxsT.Successful) -> True
+        _                                              -> False
 
 
 ----------------------------------------------------------------------------

--- a/default.nix
+++ b/default.nix
@@ -148,6 +148,20 @@ let
           # additionalNodeArgs = ""; TODO?
         };
       };
+      mainnetBlockchainImporter = mkDocker {
+        environment = "mainnet";
+        connectArgs = {
+          executable = "blockchain-importer";
+          # additionalNodeArgs = ""; TODO?
+        };
+      };
+      stagingBlockchainImporter = mkDocker {
+        environment = "mainnet-staging";
+        connectArgs = {
+          executable = "blockchain-importer";
+          # additionalNodeArgs = ""; TODO?
+        };
+      };
     };
 
     daedalus-bridge = let


### PR DESCRIPTION
## Description
Sending the same valid transaction twice (such as may happen under poor networking conditions) will cause one transaction to succeed and the other to fail.
This is expected behavior but the problem is that the resulting DB state is that the transaction "failed" despite it being properly included in the blockchain.

Fix:
Flip incorrect boolean result of a function

Note: I think this solution exposes a race condition because it follows a two step process:
1) Poll the DB to see the status of the transaction
2) If success, don't override. Otherwise override
However, what happens if after (1) returns that there is no "successful" transaction and before (2), the DB receives a "success" transaction.

## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply and `~` in the ones that do not: -->
- [~] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🛠 New feature (non-breaking change which adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🏭 Refactoring that does not change existing functionality but does improve things like code readability, structure etc
- [ ] 🔨 New or improved tests for existing code
- [ ] ⛑ git-flow chore (backport, hotfix, etc)
